### PR TITLE
Add optional offset and limit parameters

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -33,7 +33,9 @@ var controllers = require('./controllers'),
 			};
 
 		data.router.get('/friends/:uid', data.apiMiddleware.requireUser, data.apiMiddleware.requireAdmin, middleware.verifyUserExists, function(req, res) {
-			friends.getFriendsPageData(req.params.uid, req.user.uid, 0, 49, function(err, friendsData) {
+                        var offset = Number(req.query.offset || 0);
+                        var limit  = Number(req.query.limit  || 50);
+			friends.getFriendsPageData(req.params.uid, req.user.uid, offset, offset + limit - 1, function(err, friendsData) {
 				return data.errorHandler.handle(err, res, friendsData);
 			});
 		});


### PR DESCRIPTION
Allow optional offset and limit parameters to the retrieval API that, if present, will override the default values of 0 and 50.
